### PR TITLE
remove sudo, because ansible not allow sudo on an include

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -13,4 +13,3 @@
 # under the License.
 ---
 - include: config.yaml
-  sudo: yes


### PR DESCRIPTION
```
ERROR! conflicting action statements: include, sudo

The error appears to be in 'ansible/roles/ansible-semodule/tasks/main.yaml': line 15, column 3, but may be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- include: config.yaml
  ^ here
```

